### PR TITLE
added force push to jsdoc workflow closes #53

### DIFF
--- a/.github/workflows/jsdoc.yml
+++ b/.github/workflows/jsdoc.yml
@@ -47,3 +47,4 @@ jobs:
             with:
                github_token: ${{secrets.GITHUB_TOKEN}}
                branch: ${{ github.ref }}
+               force: true


### PR DESCRIPTION
Added force push for JSDoc and prettier upon push to dev. Should be safe to do as the pull request must be reviewed/approved before pushing anyway