### PR TITLE
added link to app in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ Team page Markdown file:
 [Team Page](admin/team.md)
 
 [Project documentation](./docs/README.md)
+
+##[DevDog](https://cse110-sp24-group4.github.io/cse110-sp24-group4/source/)


### PR DESCRIPTION
The github pages site defaults to the README so I added a link directly to the homepage of our app to it