### PR TITLE
fix overflow on note title input

### DIFF
--- a/source/css/notes.css
+++ b/source/css/notes.css
@@ -147,7 +147,7 @@ i {
   font-size: 1.5em; /* Adjust the size of the header as needed */
   font-weight: bold; /* Make the title bold */
   margin: 8px 0; /* Add some margin for spacing */
-  width: 100%;
+  width: 90%;
   overflow: hidden;
   text-overflow: ellipsis;
 }


### PR DESCRIPTION
adjusted width of title to account for margin and prevent overflow on mobile. If testing confirms the fix we can close 135